### PR TITLE
Remove disabled pointer events in leading-addons

### DIFF
--- a/resources/views/partials/leading-addons.blade.php
+++ b/resources/views/partials/leading-addons.blade.php
@@ -9,7 +9,7 @@
         <span class="text-slate-500 sm:text-sm sm:leading-5">{!! $inlineAddon !!}</span>
     </div>
 @elseif ($leadingIcon)
-    <div class="leading-icon absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+    <div class="leading-icon absolute inset-y-0 left-0 pl-3 flex items-center">
         <span class="h-5 w-5 text-slate-400">
             {!! $leadingIcon !!}
         </span>


### PR DESCRIPTION
So that this is the same as trailing-addon. Reason being I have decrement/increment buttons

```
<x-input class="text-center"
                                name="product_option" value="0"
                                x-model="option_quantity" min="0">
                                <x-slot name="leadingIcon">
                                    <x-heroicon-o-minus
                                        x-on:click="option_quantity--;if(option_quantity < 1){option_quantity = 0;}" />
                                </x-slot>
                                <x-slot name="trailingIcon">
                                    <x-heroicon-o-plus 
                                        x-on:click="option_quantity++" />
                                </x-slot>
                            </x-input>

```